### PR TITLE
Reproduce cookie refresh bugs, validate fixes

### DIFF
--- a/cookies.go
+++ b/cookies.go
@@ -27,6 +27,10 @@ func validateCookie(cookie *http.Cookie, seed string, expiration time.Duration) 
 		if err != nil {
 			return
 		}
+		// The expiration timestamp set when the cookie was created
+		// isn't sent back by the browser. Hence, we check whether the
+		// creation timestamp stored in the cookie falls within the
+		// window defined by (Now()-expiration, Now()].
 		t = time.Unix(int64(ts), 0)
 		if t.After(time.Now().Add(expiration*-1)) && t.Before(time.Now().Add(time.Minute*5)) {
 			// it's a valid cookie. now get the contents

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -239,7 +239,7 @@ func (p *OauthProxy) ProcessCookie(rw http.ResponseWriter, req *http.Request) (e
 	if err != nil {
 		log.Printf(err.Error())
 		ok = false
-	} else if ok && p.CookieRefresh != time.Duration(0) && value != "" {
+	} else if ok && p.CookieRefresh != time.Duration(0) {
 		refresh := timestamp.Add(p.CookieRefresh)
 		if refresh.Before(time.Now()) {
 			ok = p.Validator(email) && p.provider.ValidateToken(access_token)


### PR DESCRIPTION
Per bitly/oauth2_proxy#115, @jehiah noted that he encountered a cookie refresh
bug whereby an empty cookie value was being set when --cookie-refresh was
enabled. I was able to ascertain by studying the code that if the original
cookie has expired, the "refresh" case would still be triggered, causing an
empty cookie to be set.

TestProcessCookieFailIfRefreshSetAndCookieExpired reproduces the bug when the
`ok &&` component of the `ok && p.CookieRefresh != time.Duration(0)`
expression within ProcessCookie() is removed. The bug is confirmed fixed when
the `ok &&` component is reinstated.

At the same time, it's now apparent that the effective cookie expiration
period was always one week prior to @jehiah's changes, thanks to the timestamp
in validateCookie() being compared against the hardcoded value
`time.Duration(24)*7*time.Hour*-1`. TestProcessCookieFailIfCookieExpired
confirms that @jehiah's changes solves this problem as well.

I also took the liberty to add a comment to the timestamp comparison in
validateCookie(), since it took effort to remind myself how it was supposed to
work.
